### PR TITLE
Revert "fix: 修复页脚link到halo的地址错误 (#32)" 

### DIFF
--- a/templates/modules/footer.html
+++ b/templates/modules/footer.html
@@ -8,7 +8,7 @@
         <halo:footer />
         <p>
           Using the
-          <a href="https://jekyllrb.com" target="_blank" rel="noopener">Halo</a>
+          <a href="https://halo.run" target="_blank" rel="noopener">Halo</a>
           theme
           <a
             href="https://github.com/airbozh/halo-theme-chirpy"


### PR DESCRIPTION
Reverts https://github.com/AirboZH/halo-theme-chirpy/pull/33