### PR TITLE
 feat: 文章适配表格

### DIFF
--- a/src/js/patch/table.js
+++ b/src/js/patch/table.js
@@ -1,0 +1,17 @@
+export function addClassToTable() {
+  // 获取所有 content 下的 table 元素
+  const tables = document.querySelectorAll('.content table');
+
+  // 遍历所有 table 元素
+  tables.forEach((table) => {
+    // 创建一个 div 元素
+    const wrapper = document.createElement('div');
+    // 添加 class 属性
+    wrapper.classList.add('table-wrapper');
+    // 添加 text-align: cneter
+    wrapper.style.textAlign = 'center';
+    // 将 table 元素包裹在 div 元素内
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -12,12 +12,16 @@ import {categoryCollapse} from "./js/modules/components/category-collapse";
 import {imgLazy} from "./js/modules/components/img-lazyload";
 import {toc} from "./js/modules/components/toc";
 import {initClipboard} from "./js/modules/plugins";
+// 因为 patch/index 中有内容且没有引用, 所有没有在 index 中引入
+// 完善后以下代码应改为 import { * } from './js/patch/index';
 import {activeSidebar} from "./js/patch/sidebar";
+import {addClassToTable} from './js/patch/table';
 
 basic();
 initSidebar();
 activeSidebar();
 initTopbar();
+addClassToTable();
 categoryCollapse();
 imgLazy();
 // imgPopup();


### PR DESCRIPTION
Resolve https://github.com/AirboZH/halo-theme-chirpy/issues/129#issue-2030101655

![image](https://github.com/AirboZH/halo-theme-chirpy/assets/75354124/fa6902e6-1bce-451d-8cd6-6d7a20cd09c5)
![image](https://github.com/AirboZH/halo-theme-chirpy/assets/75354124/8d20cbe5-c598-41cd-92e7-f32d0a49216f)

> 对比[Chirpy Jekyll Theme](https://github.com/cotes2020/jekyll-theme-chirpy)主题, 发现是 `<table>` 缺少一个 `div class="table-wrapper"` 导致样式不生效, 在渲染完成后添加 `class 标签`(可能有更好的方案, 但我这边没思路)