### PR TITLE
fix: 修复版权悬浮提示显示位置异常

### DIFF
--- a/templates/links.html
+++ b/templates/links.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html
   th:replace="~{modules/layout :: html (title = '友情链接', content = ~{::content}, layout = 'page' ,breadcrumb = ~{::breadcrumb})}"
   xmlns:th="https://www.thymeleaf.org">


### PR DESCRIPTION
修复在该页面下，页脚“保留部分权利。”鼠标悬浮提示tooltip位置显示异常
fix https://github.com/AirboZH/halo-theme-chirpy/issues/179