### PR TITLE
fix：修复空文章分类显示文章数量为null

### DIFF
--- a/templates/categories.html
+++ b/templates/categories.html
@@ -29,7 +29,7 @@
               >
               <!-- content count -->
               <span class="text-muted small font-weight-light">
-                [[${category.status.visiblePostCount} + ' 篇文章']]
+                [[${category.status.visiblePostCount == null ? 0 : category.status.visiblePostCount} + ' 篇文章']]
               </span>
             </span>
             <!-- arrow -->
@@ -51,7 +51,7 @@
               <!-- content count -->
               <span class="text-muted small font-weight-light">
                 [[${#lists.size(category.children)} + '个分类 ' +
-                ${category.status.visiblePostCount} + ' 篇文章']]
+                ${category.status.visiblePostCount == null ? 0 : category.status.visiblePostCount} + ' 篇文章']]
               </span>
             </span>
             <!-- arrow -->
@@ -86,7 +86,7 @@
               >
 
               <span class="text-muted small font-weight-light">
-                [[${subcategory.status.visiblePostCount} + ' 篇文章']]
+                [[${subcategory.status.visiblePostCount == null ? '0' : subcategory.status.visiblePostCount} + ' 篇文章']]
               </span>
             </li>
           </ul>

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -50,7 +50,7 @@
               >
               <!-- content count -->
               <span class="text-muted small font-weight-light">
-                [[${#lists.size(category.children)} + '个分类 ' +
+                [[${#lists.size(category.children)} + ' 个分类 ' +
                 ${category.status.visiblePostCount == null ? 0 : category.status.visiblePostCount} + ' 篇文章']]
               </span>
             </span>


### PR DESCRIPTION
对分类下的的文章数量（visiblePostCount字段）进行了判空处理。修复页面显示`null 篇文章`的问题